### PR TITLE
Update organisations for Scrutinizer and Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Step-up U2fBundle
-[![Build Status](https://travis-ci.org/SURFnet/Stepup-u2f-bundle.svg)](https://travis-ci.org/SURFnet/Stepup-u2f-bundle) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/SURFnet/Stepup-u2f-bundle/badges/quality-score.png?b=develop)](https://scrutinizer-ci.com/g/SURFnet/Stepup-u2f-bundle/?branch=develop)
+[![Build Status](https://travis-ci.org/OpenConext/Stepup-u2f-bundle.svg)](https://travis-ci.org/OpenConext/Stepup-u2f-bundle) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/OpenConext/Stepup-u2f-bundle/badges/quality-score.png?b=develop)](https://scrutinizer-ci.com/g/OpenConext/Stepup-u2f-bundle/?branch=develop)
 
 The SURFnet Step-up U2F Bundle contains server-side device verification, and the necessary forms and resources to enable client-side U2F interaction with Step-up Identities
 


### PR DESCRIPTION
[135688937](https://www.pivotaltracker.com/story/show/135688937)
Stepup repositories have been moved to the OpenConext organisation