### PR TITLE
Adjust composer version constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,22 @@
 
 language: php
 
+addons:
+  apt:
+    packages:
+      - ant
+
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+
 
 matrix:
   allow_failures:
     - php: 7.1
-    - php: 7.2
+    - php: 7.4
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": ">=5.4|^7",
-        "symfony/config": ">=2.7,<4",
-        "symfony/dependency-injection": ">=2.7,<4",
-        "symfony/form": ">=2.7,<4",
-        "symfony/http-kernel": ">=2.7,<4",
-        "symfony/validator": ">=2.7,<4",
+        "php": "^7",
+        "symfony/config": "^3.4|^4.4",
+        "symfony/dependency-injection": "^3.4|^4.4",
+        "symfony/form": "^3.4|^4.4",
+        "symfony/http-kernel": "^3.4|^4.4",
+        "symfony/validator": "^3.4|^4.4",
         "yubico/u2flib-server": "^0.1.0"
     },
     "require-dev": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,9 +28,9 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder;
+        $treeBuilder = new TreeBuilder('surfnet_stepup_u2f');
 
-        $rootNode = $treeBuilder->root('surfnet_stepup_u2f');
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode
             ->children()
                 ->scalarNode('app_id')

--- a/src/Service/U2fService.php
+++ b/src/Service/U2fService.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupU2fBundle\Service;
 
+use stdClass;
 use Surfnet\StepupU2fBundle\Dto\RegisterRequest;
 use Surfnet\StepupU2fBundle\Dto\RegisterResponse;
 use Surfnet\StepupU2fBundle\Dto\Registration;
@@ -90,7 +91,7 @@ class U2fService
 
         $yubicoRequest = new YubicoRegisterRequest($request->challenge, $request->appId);
 
-        $yubicoResponse = new \stdClass;
+        $yubicoResponse = new stdClass;
         $yubicoResponse->clientData = $response->clientData;
         $yubicoResponse->registrationData = $response->registrationData;
 
@@ -178,7 +179,7 @@ class U2fService
         $yubicoRequest->appId     = $request->appId;
         $yubicoRequest->keyHandle = $request->keyHandle;
 
-        $yubicoResponse = new \stdClass;
+        $yubicoResponse = new stdClass;
         $yubicoResponse->keyHandle     = $response->keyHandle;
         $yubicoResponse->signatureData = $response->signatureData;
         $yubicoResponse->clientData    = $response->clientData;


### PR DESCRIPTION
This change will bump the version constraints to allow Symfony 4 support and
drop php5.6 support.